### PR TITLE
PRO-16914: ProvarDX VSCode Extension Creates Invalid Property File on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "provardx-vscode" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## 1.0.1 - 2020-09-24
+## 1.0.1 - 2020-09-25
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "provardx-vscode" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 1.0.1 - 2020-09-24
+
+### Fixed
+
+-   Invalid Property File was generated on Windows because backslash('\') was not escaped in the file paths
+
 ## 1.0.0 - 2020-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "provardx-vscode" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## 1.0.1 - 2020-09-25
+## 1.0.1 - 2020-09-28
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "provardx-vscode",
     "displayName": "ProvarDX",
     "description": "Provides integration with the ProvarDX SFDX Plugin",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "publisher": "ProvarTesting",
     "author": {
         "name": "Make Positive Provar Ltd",

--- a/src/commands/createPropertiesFile.ts
+++ b/src/commands/createPropertiesFile.ts
@@ -113,9 +113,12 @@ class CreatePropertiesFile {
     ): Promise<void> {
         const resultsPath = path.join(provarProjectUri, 'ANT', 'Results');
 
-        const propertiesFileConent = DEFAULT_PROPERTIES_FILE_CONTENT.replace('{{provarHome}}', provarHomeUri)
-            .replace('{{projectPath}}', provarProjectUri)
-            .replace('{{resultsPath}}', resultsPath);
+        const propertiesFileConent = DEFAULT_PROPERTIES_FILE_CONTENT.replace(
+            '{{provarHome}}',
+            this.escapeSlashInFolderUri(provarHomeUri)
+        )
+            .replace('{{projectPath}}', this.escapeSlashInFolderUri(provarProjectUri))
+            .replace('{{resultsPath}}', this.escapeSlashInFolderUri(resultsPath));
 
         const propertiesFilePath = path.join(folderUri, fileName);
         fs.writeFileSync(propertiesFilePath, propertiesFileConent);
@@ -131,6 +134,10 @@ class CreatePropertiesFile {
             case 'win32':
                 return process.env.PROVAR_HOME || path.join('C:\\', 'Program Files', 'Provar');
         }
+    }
+
+    private escapeSlashInFolderUri(folderUri: string): string {
+        return folderUri.replace(/\\/g, '/');
     }
 }
 


### PR DESCRIPTION


Issue: backslash('\') was not escaped in the file paths